### PR TITLE
Allow TLS in addition to SSL3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ OPTFLAGS += -DSO_REUSEPORT
 
 # END system dependant block
 
-SSL_LIBS := $(shell pkg-config --libs libssl 2>/dev/null)
-ifeq ($(SSL_LIBS),)
 SSL_LIBS := $(shell pkg-config --libs openssl 2>/dev/null)
+ifeq ($(SSL_LIBS),)
+SSL_LIBS := $(shell pkg-config --libs libssl 2>/dev/null)
 endif
 ifeq ($(SSL_LIBS),)
 SSL_LIBS := -lssl -lcrypto

--- a/ptstream.c
+++ b/ptstream.c
@@ -151,7 +151,7 @@ int stream_enable_ssl(PTSTREAM *pts) {
 	
 	/* Initialise the connection */
 	SSLeay_add_ssl_algorithms();
-	meth = SSLv3_client_method();
+	meth = SSLv23_client_method();
 	SSL_load_error_strings();
 
 	ctx = SSL_CTX_new (meth);


### PR DESCRIPTION
Apache 2.4 by default disables SSLv3.

> `# Don't use SSLv2 anymore as it's considered to be broken security-wise.`
> `# Also disable SSLv3 as most modern browsers are capable of TLS.`
> `SSLProtocol ALL -SSLv2 -SSLv3`


So this patch enables TLS.
I also had to patch the Makefile to avoid the SSL_LIBS being set to just `-lssl` instead of `-lssl -lcrypto` which led to problems with linking ntlm (a problem which will probably resurface on a platform which lacks openssl).

Back to SSLv3/TLS:
From https://www.openssl.org/docs/ssl/SSL_CTX_new.html:

> SSLv23_method(void), SSLv23_server_method(void), SSLv23_client_method(void)
> A TLS/SSL connection established with these methods may understand the SSLv3, TLSv1,  TLSv1.1 and TLSv1.2 protocols.
> If extensions are required (for example server name) a client will send out TLSv1 client hello messages including extensions and will indicate that it also understands TLSv1.1, TLSv1.2 and permits a fallback to SSLv3. A server will support SSLv3, TLSv1, TLSv1.1 and TLSv1.2 protocols. This is the best choice when compatibility is a concern.