### PR TITLE
Make 'make' work out of the box for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,6 @@ mandir = $(datadir)/man
 # Remove strlcpy/strlcat on (open)bsd/darwin systems
 OBJ = proxytunnel.o	\
 	base64.o	\
-	strlcpy.o	\
-	strlcat.o	\
 	strzcat.o	\
 	setproctitle.o	\
 	io.o		\
@@ -75,6 +73,12 @@ OBJ = proxytunnel.o	\
 	cmdline.o	\
 	ntlm.o		\
 	ptstream.o
+
+UNAME = $(shell uname)
+ifneq ($(UNAME),Darwin)
+OBJ += strlcpy.o	\
+	strlcat.o
+endif
 
 .PHONY: all clean docs install
 

--- a/proxytunnel.h
+++ b/proxytunnel.h
@@ -32,8 +32,14 @@ void closeall();
 void do_daemon();
 void initsetproctitle(int argc, char *argv[]);
 void setproctitle(const char *fmt, ...);
+
+#if defined(__APPLE__) && defined(__MACH__)
+/* Don't include strlcat and strlcpy since they are provided as macros on OSX */
+#else
 size_t strlcat(char *dst, const char *src, size_t siz);
 size_t strlcpy(char *dst, const char *src, size_t siz);
+#endif
+
 size_t strzcat(char *dst, char *format, ...);
 int main( int argc, char *argv[] );
 char * readpassphrase(const char *, char *, size_t, int);


### PR DESCRIPTION
Excluding declarations of strlcat() and strlcpy() from proxytunnel.h
Exclucing building strlcat.o and strlcpy.o from the Makefile

This makes 'make' work on OSX without the need for editing those files.