### PR TITLE
Makefile: don't use non-portable -D option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ clean:
 	$(MAKE) -C docs clean
 
 install:
-	install -Dp -m0755 $(name) $(DESTDIR)$(bindir)/$(name)
+	install -d $(DESTDIR)$(bindir)
+	install -p -m555 $(name) $(DESTDIR)$(bindir)
 	$(MAKE) -C docs install
 
 .c.o:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,7 +8,8 @@ htmltargets = $(patsubst %.adoc, %.html, $(adoctargets))
 docs: proxytunnel.1 $(htmltargets)
 
 install: proxytunnel.1
-	install -Dp -m0644 proxytunnel.1 $(DESTDIR)$(mandir)/man1/proxytunnel.1
+	install -d $(DESTDIR)$(mandir)/man1
+	install -p proxytunnel.1 $(DESTDIR)$(mandir)/man1
 
 clean:
 	rm -f proxytunnel.1 *.html *.xml


### PR DESCRIPTION
This fixes the build with the BSD install command by eschewing the GNU
specific -D option, which is not portable.