### PR TITLE
Fix global variable declarations/definitions for GCC 10 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ OBJ = proxytunnel.o	\
 	readpassphrase.o	\
 	messages.o	\
 	cmdline.o	\
+	globals.o	\
 	ntlm.o		\
 	ptstream.o
 

--- a/globals.c
+++ b/globals.c
@@ -1,0 +1,41 @@
+/* Proxytunnel - (C) 2001-2008 Jos Visser / Mark Janssen    */
+/* Contact:                  josv@osp.nl / maniac@maniac.nl */
+
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+/* globals.c */
+
+#include "proxytunnel.h"
+
+/* Globals */
+char *program_name;             /* Guess what? */
+int i_am_daemon;                /* Also... */
+
+PTSTREAM *stunnel;	/* stream representing the socket from us to proxy */
+PTSTREAM *std;		/* stream representing stdin/stdout */
+
+/*
+ * All the command line options
+ */
+struct gengetopt_args_info args_info;
+
+char buf[SIZE];         /* Data transfer buffer */
+
+char ntlm_type1_buf[160];
+char ntlm_type3_buf[4096];
+
+// vim:noexpandtab:ts=4

--- a/ntlm.h
+++ b/ntlm.h
@@ -26,8 +26,8 @@ void build_ntlm2_response();
 
 extern int ntlm_challenge;
 
-char ntlm_type1_buf[160];
-char ntlm_type3_buf[4096];
+extern char ntlm_type1_buf[160];
+extern char ntlm_type3_buf[4096];
 
 
 // Below are the flag definitions.

--- a/proxytunnel.h
+++ b/proxytunnel.h
@@ -46,21 +46,21 @@ char * readpassphrase(const char *, char *, size_t, int);
 char * getpass_x(const char *format, ...);
 
 /* Globals */
-int read_fd;                    /* The file descriptor to read from */
-int write_fd;                   /* The file destriptor to write to */
-char *program_name;             /* Guess what? */
-int i_am_daemon;                /* Also... */
+extern int read_fd;                    /* The file descriptor to read from */
+extern int write_fd;                   /* The file descriptor to write to */
+extern char *program_name;             /* Guess what? */
+extern int i_am_daemon;                /* Also... */
 
-PTSTREAM *stunnel;	/* stream representing the socket from us to proxy */
-PTSTREAM *std;		/* stream representing stdin/stdout */
+extern PTSTREAM *stunnel;	/* stream representing the socket from us to proxy */
+extern PTSTREAM *std;		/* stream representing stdin/stdout */
 
 /*
  * All the command line options
  */
-struct gengetopt_args_info args_info;
+extern struct gengetopt_args_info args_info;
 
 #define SIZE 65536
-char buf[SIZE];         /* Data transfer buffer */
+extern char buf[SIZE];         /* Data transfer buffer */
 
 /*
  * Small MAX macro


### PR DESCRIPTION
This boils down to declaring global variables as "extern" in header files and defining them in just one place.

See https://www.gnu.org/software/gcc/gcc-10/porting_to.html