### PR TITLE
Remediate faulty patch for #57

### DIFF
--- a/ptstream.c
+++ b/ptstream.c
@@ -341,11 +341,10 @@ int stream_enable_ssl(PTSTREAM *pts, const char *proxy_arg) {
 		message( "Set SNI hostname to %s\n", peer_host);
 	}
 	res = SSL_set_tlsext_host_name(ssl, peer_host);
-	if (res != SSL_TLSEXT_ERR_OK) {
-		unsigned long ssl_err = (res == SSL_TLSEXT_ERR_ALERT_WARNING ? SSL_TLSEXT_ERR_ALERT_WARNING : ERR_get_error());
-		message( "SSL_set_tlsext_host_name returned: %lu (0x%lx). "
-		         "TLS SNI error, giving up\n", ssl_err, ssl_err );
-		exit( 1 );
+	if ( res != 1 ) {
+		message( "SSL_set_tlsext_host_name() failed for host name '%s'. "
+		         "TLS SNI error, giving up\n", peer_host);
+		goto fail;
 	}
 	
 	if ( SSL_connect (ssl) <= 0) {

--- a/ptstream.h
+++ b/ptstream.h
@@ -21,7 +21,6 @@
 
 #ifdef USE_SSL
 #include <openssl/crypto.h>
-#include <openssl/err.h>
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>


### PR DESCRIPTION
This patch fixes what has been discussed in #57 after being closed and what has been logged with #59 as a new issue.

The fact that commit 4bac945 breaks SSL connections was verified while preparing proxytunnel 1.11 for Debian. Debian's proxytunnel 1.11-1 already contains the patch.

Please review, merge and tag a new version of proxytunnel.