### PR TITLE
Bind IP address option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ proxytunnel.exe
 proxytunnel
 passfile
 test.sh
+*.orig
+*.rej
+/docs/proxytunnel-paper.html
+/docs/proxytunnel.1
+/docs/proxytunnel.1.html

--- a/cmdline.h
+++ b/cmdline.h
@@ -23,6 +23,8 @@
 #ifndef _cmdline_h
 #define _cmdline_h
 
+#include <netinet/in.h>
+
 #define MAX_HEADER_SIZE 1024
 
 struct gengetopt_args_info {
@@ -44,6 +46,7 @@ struct gengetopt_args_info {
 	int inetd_flag;			/* Turn on inetd (default=off). */
 	int quiet_flag;			/* Turn on quiet mode (default=off). */
 	int standalone_arg;		/* Turn on stdalone (-a) on port */
+	struct in_addr hostip_arg; /* Host IP to listen on (-I) */
 	int encrypt_flag;		/* Turn on SSL encryption (default=off). */
 	int encryptproxy_flag;	/* Turn on client to proxy SSL encryption (def=off).*/
 	int encryptremproxy_flag;  /* Turn on local to remote proxy SSL encryption (def=off).*/

--- a/docs/proxytunnel.1.adoc
+++ b/docs/proxytunnel.1.adoc
@@ -21,6 +21,9 @@ also be used for other proxy-traversing purposes like proxy bouncing.
 *-i*, *--inetd*::
     Run from inetd (default: off)
 
+*-I*, *--hostip*=_ipv4address_::
+    Run as standalone daemon on the specified IP address (default: 0.0.0.0)
+
 *-a*, *--standalone*=_port_::
     Run as standalone daemon on specified _port_
 

--- a/proxytunnel.c
+++ b/proxytunnel.c
@@ -27,7 +27,6 @@
 #include <netinet/tcp.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <signal.h>
@@ -187,7 +186,7 @@ void do_daemon()
 
 	memset( &sa_serv, '\0', sizeof( sa_serv ) );
 	sa_serv.sin_family = AF_INET;
-	sa_serv.sin_addr.s_addr = htonl(INADDR_ANY);
+	sa_serv.sin_addr.s_addr = args_info.hostip_arg.s_addr;
 	sa_serv.sin_port = htons( args_info.standalone_arg );
 
 	if ( bind( listen_sd, (struct sockaddr * )&sa_serv, sizeof( struct sockaddr ) ) < 0) {


### PR DESCRIPTION
 New option -I: IP address to bind(2) to
    
 When running multiple instances of the proxytunnel
 it is useful to give them explicit IP addresses
 to bind(2) to.
    
 Only IPv4 is supported for the standalone daemon.