### PR TITLE
Fix and improve ntlm authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ OPTFLAGS += -DSETPROCTITLE -DSPT_TYPE=2
 # System dependant blocks... if your system is listed below, uncomment
 # the relevant lines
 
+# MSYS
+# The current version of gcc from MSYS defines __MSYS__ and __CYGWIN__.
+# To avoid to change the code, simply define CYGWIN additionally. 
+ifneq ($(filter $(MSYSTEM),MSYS MINGW32 MINGW64 UCRT64),)
+CFLAGS += -DCYGWIN
+endif
+
 # OpenBSD
 #OPTFLAGS += -DHAVE_SYS_PSTAT_H
 

--- a/buildwin.sh
+++ b/buildwin.sh
@@ -4,13 +4,13 @@ echo "Build docs..."
 make -C docs
 
 echo "Build proxytunnel..."
-make -f Makefile.ssl11
-
-echo "Copy msys/openssl dll to build dir..."
-cp  /usr/bin/msys-2.0.dll /usr/bin/msys-crypto-1.1.dll /usr/bin/msys-ssl-1.1.dll /usr/bin/msys-z.dll .
+make -f Makefile
+strip -s proxytunnel.exe
 
 echo "Generate proxytunnel.zip with docs, exe and msys/openssl dll..."
-zip proxytunnel.zip proxytunnel.exe *.dll docs/proxytunnel.1 docs/proxytunnel.1.html docs/proxytunnel-paper.html
+zip proxytunnel.zip proxytunnel.exe docs/proxytunnel.1 docs/proxytunnel.1.html docs/proxytunnel-paper.html
+DLLS="$(ldd proxytunnel.exe | grep msys.*\.dll | awk '{print $3}' | xargs) /usr/lib/ossl-modules/legacy.dll"
+zip proxytunnel.zip -j $DLLS 
 
 if [ ! -z "${TRAVIS_TAG}" ]; then 
 echo "Deploy proxytunnel.zip to github release tag:${TRAVIS_TAG}..."


### PR DESCRIPTION
Fixed loading of default and legacy provider
- Verify that the default and legacy provider was loaded successfully. If not bail out.
- On Windows, try to load the legacy.dll from multiple locations before bailing out.
- Added legacy.dll to the proxytunnel.zip archive.

Fixed NTLM authentication
- analyse_HTTP: Read first something from the connection before analyse it
- analyse_HTTP: Accepte a TAB as a second delimiter during parsing an answer from a proxy.
- proxy_protocol(): In case of NTLM authentication, this function is called twice recursively.
  Use variable ntlm_challenge as marker of the state of the authentication to avoid endless
  recursive calls in case of an error and avoid to try to connect to the remote proxy twice.