### PR TITLE
Use the credential manager on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ OPTFLAGS += -DSETPROCTITLE -DSPT_TYPE=2
 # To avoid to change the code, simply define CYGWIN additionally. 
 ifneq ($(filter $(MSYSTEM),MSYS MINGW32 MINGW64 UCRT64),)
 CFLAGS += -DCYGWIN
+OPTFLAGS += -DUSE_WINCREDMAN
+LDFLAGS += -lcredui
+MSYS=1
 endif
 
 # OpenBSD
@@ -76,6 +79,10 @@ OBJ = proxytunnel.o	\
 	globals.o	\
 	ntlm.o		\
 	ptstream.o
+
+ifeq ($(MSYS),1)
+OBJ += readcredential.o
+endif
 
 UNAME = $(shell uname)
 ifneq ($(UNAME),Darwin)

--- a/cmdline.c
+++ b/cmdline.c
@@ -98,6 +98,9 @@ void cmdline_parser_print_help (void) {
 #ifdef SETPROCTITLE
 " -x, --proctitle=STRING     Use a different process title\n"
 #endif
+#ifdef USE_WINCREDMAN
+" -m                         Use the credential manager for passwords\n"
+#endif
 "\n"
 "Miscellaneous options:\n"
 " -v, --verbose              Turn on verbosity\n"
@@ -164,7 +167,7 @@ int cmdline_parser( int argc, char * const *argv, struct gengetopt_args_info *ar
 	/* args_info->enforcetls1_given = 0; */
 	args_info->host_given = 0;
 	args_info->cacert_given = 0;
-
+	args_info->credman_flag = 0;
 /* No... we can't make this a function... -- Maniac */
 #define clear_args() \
 { \
@@ -202,6 +205,7 @@ int cmdline_parser( int argc, char * const *argv, struct gengetopt_args_info *ar
 	args_info->cacert_arg = NULL; \
 	args_info->enforceipv4_flag = 0; \
 	args_info->enforceipv6_flag = 0; \
+	args_info->credman_flag = 0; \
 }
 
 	clear_args();
@@ -253,9 +257,9 @@ int cmdline_parser( int argc, char * const *argv, struct gengetopt_args_info *ar
 			{ NULL,				0, NULL, 0 }
 		};
 
-		c = getopt_long (argc, argv, "hVia:u:s:t:F:p:P:r:R:d:H:x:c:k:vNeEXWBqLo:TzC:46", long_options, &option_index);
+		c = getopt_long (argc, argv, "hVia:u:s:t:F:p:P:r:R:d:H:x:c:k:mvNeEXWBqLo:TzC:46", long_options, &option_index);
 #else
-		c = getopt( argc, argv, "hVia:u:s:t:F:p:P:r:R:d:H:x:c:k:vNeEXWBqLo:TzC:46" );
+		c = getopt( argc, argv, "hVia:u:s:t:F:p:P:r:R:d:H:x:c:k:mvNeEXWBqLo:TzC:46" );
 #endif
 
 		if (c == -1)
@@ -349,6 +353,13 @@ int cmdline_parser( int argc, char * const *argv, struct gengetopt_args_info *ar
 				args_info->proctitle_arg = gengetopt_strdup (optarg);
 				break;
 
+#ifdef USE_WINCREDMAN
+			case 'm':
+				args_info->credman_flag = 1;
+				if( args_info->verbose_flag )
+					message( "Use credential manager for passwords\n");
+				break;
+#endif
 			case 'L':
 				/* args_info->enforcetls1_given = 1;
 				message("Enforcing TLSv1\n");

--- a/cmdline.h
+++ b/cmdline.h
@@ -93,6 +93,7 @@ struct gengetopt_args_info {
 	/* int enforcetls1_given;    Wheter to enforce TLSv1 */
 	int host_given;         /* Wheter we override the Host Header */
 	int cacert_given;		/* Whether cacert was given */
+	int credman_flag;       /* Use credential manager to get passwords instead reading it from console. */
 };
 
 int cmdline_parser( int argc, char * const *argv, struct gengetopt_args_info *args_info );

--- a/proxytunnel.c
+++ b/proxytunnel.c
@@ -428,7 +428,15 @@ int main( int argc, char *argv[] ) {
 	/* If the usename is given, but password is not, prompt for it */
 	if( args_info.user_given && !args_info.pass_given ) {
 		char *cp;
+#ifdef USE_WINCREDMAN
+		if (args_info.credman_flag) {
+			cp = getcred_x (args_info.proxy_arg, args_info.user_arg);
+		} else {
+			cp = getpass_x ("Enter local proxy password for user %s: ", args_info.user_arg);
+		}
+#else
 		cp = getpass_x ("Enter local proxy password for user %s: ", args_info.user_arg);
+#endif
 		if (cp != NULL && strlen (cp) > 0) {
 			args_info.pass_arg = strdup (cp);
 			args_info.pass_given = 1;
@@ -438,7 +446,15 @@ int main( int argc, char *argv[] ) {
 
 	if( args_info.remuser_given && !args_info.rempass_given ) {
 		char *cp;
+#ifdef USE_WINCREDMAN
+		if (args_info.credman_flag) {
+			cp = getcred_x (args_info.remproxy_arg, args_info.remuser_arg);
+		} else {
+			cp = getpass_x ("Enter remote proxy password for user %s: ", args_info.remuser_arg);
+		}
+#else
 		cp = getpass_x ("Enter remote proxy password for user %s: ", args_info.remuser_arg);
+#endif
 		if (cp != NULL && strlen (cp) > 0) {
 			args_info.rempass_arg = strdup (cp);
 			args_info.rempass_given = 1;

--- a/proxytunnel.h
+++ b/proxytunnel.h
@@ -44,6 +44,9 @@ size_t strzcat(char *dst, char *format, ...);
 int main( int argc, char *argv[] );
 char * readpassphrase(const char *, char *, size_t, int);
 char * getpass_x(const char *format, ...);
+#ifdef USE_WINCREDMAN
+char* getcred_x(const char*, const char*);
+#endif
 
 /* Globals */
 extern int read_fd;                    /* The file descriptor to read from */

--- a/readcredential.c
+++ b/readcredential.c
@@ -1,0 +1,229 @@
+/* Proxytunnel - (C) 2024    Jos Visser / Mark Janssen / Hartmut Birr          */
+/* Contact:                  josv@osp.nl / maniac@maniac.nl / e9hack@gmail.com */
+
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include <stdio.h>
+#include <windef.h>
+#include <wincred.h>
+#include <winerror.h>
+#include <wchar.h>
+
+#include "config.h"
+
+#ifndef _countof
+#define _countof(x)	sizeof((x)) / sizeof((x)[0])
+#endif
+
+#ifndef CRED_PACK_PROTECTED_CREDENTIALS
+// missing in wincred.h
+#define CRED_PACK_PROTECTED_CREDENTIALS		0x1
+#endif
+
+char* getcred_x(const char *server, const char* user) {
+	static char buf[_PASSWORD_LEN + 1];
+	char *tmp = (char*)strchr(server, ':');
+	const char* proto = "http";
+	char *target;
+	BOOL res;
+	BOOL found = FALSE;
+	PCREDENTIAL pcred;
+	unsigned tmp_len;
+	
+	memset(buf, 0, sizeof(buf));
+
+	if (tmp) {
+		tmp_len = tmp - server;
+		if ((unsigned)atoi(tmp + 1) == 443)
+			proto = "https";
+		tmp = (char*)alloca(tmp_len + 1);
+		strncpy(tmp, server, tmp_len);
+		tmp[tmp_len] = 0;
+		server = tmp;
+	}
+
+	tmp_len = strlen(server) + sizeof("proxytunnel:://@") + strlen(proto) + strlen(user);
+	target = (char*)alloca(tmp_len);
+	sprintf(target, "proxytunnel:%s://%s", proto, server);
+
+	pcred = NULL;
+	res = CredRead(target, CRED_TYPE_GENERIC, 0, &pcred);
+	if (res) { 
+		if (pcred && pcred->UserName && !strcmp(user, pcred->UserName)) {
+			tmp_len = pcred->CredentialBlobSize / sizeof(wchar_t);
+			if (tmp_len < _countof(buf)) {
+				snprintf(buf, tmp_len, "%S", (wchar_t*)pcred->CredentialBlob);
+				buf[tmp_len] = 0;
+			}
+			CredFree(pcred);
+			return buf;
+		}
+		CredFree(pcred);
+		res = FALSE;
+		found = TRUE;
+	}
+
+	if (!res) {
+		sprintf(target, "proxytunnel:%s://%s@%s", proto, user, server);
+		pcred = NULL;
+		res = CredRead(target, CRED_TYPE_GENERIC, 0, &pcred);
+		if (res) {
+			tmp_len = pcred->CredentialBlobSize / sizeof(wchar_t);
+			if (tmp_len < _countof(buf)) {
+				snprintf(buf, tmp_len, "%S", (wchar_t*)pcred->CredentialBlob);
+				buf[tmp_len] = 0;
+			}
+			CredFree(pcred);
+			return buf;
+		}
+	}
+
+	if (!res)
+	{
+		wchar_t *w_user;
+		wchar_t *w_message;
+		CREDUI_INFOW cui;
+		PBYTE authInBuffer;
+		ULONG authInBufferSize = 0;
+		DWORD size;
+		DWORD authPackage = 0;
+		PVOID authOutBuffer;
+		ULONG authOutBufferSize = 0;
+
+		tmp_len = sizeof("Enter credentials for '://@'") +
+					strlen(user) + strlen(proto) + strlen(server);
+		w_message = (wchar_t*)alloca(tmp_len * sizeof(wchar_t));
+		if (found) {
+
+#ifdef __GNUC__
+			swprintf(w_message, tmp_len, L"Enter credentials for '%s://%s@%s'", proto, user, server);
+#else
+			swprintf(w_message, tmp_len, L"Enter credentials for '%S://%S@%S'", proto, user, server);
+#endif
+		} else {
+#ifdef __GNUC__
+			swprintf(w_message, tmp_len, L"Enter credentials for '%s://%s'", proto, server);
+#else
+			swprintf(w_message, tmp_len, L"Enter credentials for '%S://%S'", proto, server);
+#endif
+		}
+
+		tmp_len = strlen(user) + 1;
+		w_user = (wchar_t*)alloca(tmp_len * sizeof(wchar_t));
+#ifdef __GNUC__
+		swprintf(w_user, tmp_len, L"%s", user);
+#else
+		swprintf(w_user, tmp_len, L"%S", user);
+#endif
+
+		memset(&cui, 0, sizeof(cui));
+		cui.cbSize = sizeof(cui);
+		cui.hwndParent = NULL;
+		cui.pszMessageText = w_message;
+		cui.pszCaptionText = L"Proxytunnel Credential Manager";
+		cui.hbmBanner = NULL;
+
+		authInBuffer = NULL;
+		authInBufferSize = 0;
+
+		res = CredPackAuthenticationBufferW(CRED_PACK_PROTECTED_CREDENTIALS,
+											w_user,
+											L"",
+											authInBuffer,
+											&authInBufferSize);
+
+		authInBuffer = (PBYTE)alloca(authInBufferSize);
+
+		res = CredPackAuthenticationBufferW(CRED_PACK_PROTECTED_CREDENTIALS,
+											w_user,
+											L"",
+											authInBuffer,
+											&authInBufferSize);
+
+		// only the unicode variant of this function does work on windows 10
+		size = CredUIPromptForWindowsCredentialsW(&cui,
+												  0,
+												  &(authPackage),
+												  authInBuffer,
+												  authInBufferSize,
+												  &authOutBuffer,
+												  &authOutBufferSize, 
+												  NULL,
+												  CREDUIWIN_GENERIC);
+
+		if (size == ERROR_SUCCESS) {
+			wchar_t *pwsUserName;
+			DWORD cbSizeUserName = 0;
+			wchar_t *pwsDomainName;
+			ULONG cbSizeDomainName = 0;
+			wchar_t *pwsPassword;
+			DWORD cbSizePassword = 0;
+
+			res = CredUnPackAuthenticationBufferW(CRED_PACK_PROTECTED_CREDENTIALS,
+												  authOutBuffer,
+												  authOutBufferSize,
+												  NULL,
+												  &cbSizeUserName,
+												  NULL,
+												  &cbSizeDomainName,
+												  NULL,
+												  &cbSizePassword);
+
+			pwsUserName = cbSizeUserName ? (wchar_t*)alloca(cbSizeUserName * sizeof(wchar_t)) : NULL;
+			pwsDomainName = cbSizeDomainName ? (wchar_t*)alloca(cbSizeDomainName * sizeof(wchar_t)) : NULL;
+			pwsPassword = cbSizePassword ? (wchar_t*)alloca(cbSizePassword * sizeof(wchar_t)) : NULL;
+
+			res = CredUnPackAuthenticationBufferW(CRED_PACK_PROTECTED_CREDENTIALS,
+												  authOutBuffer,
+												  authOutBufferSize,
+												  pwsUserName,
+												  &cbSizeUserName,
+												  pwsDomainName,
+												  &cbSizeDomainName,
+												  pwsPassword,
+												  &cbSizePassword);
+
+			memset(authOutBuffer, 0, authOutBufferSize);
+
+			if (res) {
+				CREDENTIALA cred;
+				if (cbSizeUserName <= _countof(buf)) {
+					sprintf(buf, "%S", pwsPassword);
+				}
+
+				if (!found)
+					sprintf(target, "proxytunnel:%s://%s", proto, server);
+
+				memset(&cred, 0, sizeof(cred));
+				cred.Type = CRED_TYPE_GENERIC;
+				cred.TargetName = target;
+				cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+				cred.CredentialBlobSize = cbSizePassword * sizeof(wchar_t);
+				cred.CredentialBlob = (LPBYTE)pwsPassword;
+				cred.UserName = (char*)user;
+
+				res = CredWrite(&cred, 0);
+
+				memset(pwsUserName, 0, cbSizeUserName * sizeof(wchar_t));
+				memset(pwsDomainName, 0, cbSizeDomainName * sizeof(wchar_t));
+				memset(pwsPassword, 0, cbSizePassword * sizeof(wchar_t));
+			}
+		}
+	}
+
+	return buf;
+}


### PR DESCRIPTION
Some tools doesn't allow enter passwords on the console for ssh or tools used by ssh.
Sourcetree is such an example. To avoid to store passwords as environment variable or
in unencrypted files, on Windows the credential manager can be used. If no password
is given with parameter -P (or -R) and the additoinal parameter -m is given, proxytunnel
uses the credential manager. If the password for a given user and url is not stored
by the credential manager yet, it will pop up a window to enter the password.
At any later access, this password will be used. If it is necessary to change the password,
the entry in the credential manager must be delete manually. The entries can be identify
by the prefix proxytunnel and the url. At the next access the credential manager will
popup a window again. 