### PR TITLE
Replacement for pull request #83 (Avoid printing unterminated string in readline())

### DIFF
--- a/io.c
+++ b/io.c
@@ -58,7 +58,7 @@ int readline(PTSTREAM *pts) {
 	if ( args_info.verbose_flag )
 		/* print an additional newline if the string doesn't end with a newline */
 		message( c == '\n' ? " <- %s" : " <- %s\n", buf);
-	}
+
 	return len;
 }
 


### PR DESCRIPTION
Current solution:
- We allocate a buffer via calloc that is never released again
- The string is already NULL terminated. An additional buffer to add a NULL terminator is superfluous.
- In most cases, the string has already a trailing new-line which results in printing an additional empty line.
- strlen() is called three times, even that the length of the string is known

Simplify function readline()
- Allocating of an addional buffer isn't necessary
- Avoid printing empty lines, if the string already contains a trailing new-line