### PR TITLE
Increase MAX_HEADER_SIZE

### DIFF
--- a/cmdline.h
+++ b/cmdline.h
@@ -23,7 +23,7 @@
 #ifndef _cmdline_h
 #define _cmdline_h
 
-#define MAX_HEADER_SIZE 1024
+#define MAX_HEADER_SIZE 4096
 
 struct gengetopt_args_info {
 	char *user_arg;			/* Username to send to HTTPS proxy for auth. */


### PR DESCRIPTION
Increases the MAX_HEADER_SIZE in cmdline to be 4K

Many servers now support up to 8K of headers and beyond. Even your typical JWT is now typically larger than 1K, so increasing this to 4K to have better support with different header payload options.