### PR TITLE
OpenSSL 3.x tpm2 provider support for TSS2 private keys

### DIFF
--- a/buildwin.sh
+++ b/buildwin.sh
@@ -1,16 +1,16 @@
 # msys2 windows build script
 
-echo "Build docs..."
-make -C docs
-
 echo "Build proxytunnel..."
-make -f Makefile
-strip -s proxytunnel.exe
+make
+
+echo "Build docs..."
+make docs
+
+echo "Copy msys/openssl dll to build dir..."
+cp  /usr/bin/msys-2.0.dll /usr/bin/msys-crypto-3.dll /usr/bin/msys-ssl-3.dll /usr/bin/msys-z.dll .
 
 echo "Generate proxytunnel.zip with docs, exe and msys/openssl dll..."
-zip proxytunnel.zip proxytunnel.exe docs/proxytunnel.1 docs/proxytunnel.1.html docs/proxytunnel-paper.html
-DLLS="$(ldd proxytunnel.exe | grep msys.*\.dll | awk '{print $3}' | xargs) /usr/lib/ossl-modules/legacy.dll"
-zip proxytunnel.zip -j $DLLS 
+zip proxytunnel.zip proxytunnel.exe *.dll docs/proxytunnel.1 docs/proxytunnel.1.html docs/proxytunnel-paper.html
 
 if [ ! -z "${TRAVIS_TAG}" ]; then 
 echo "Deploy proxytunnel.zip to github release tag:${TRAVIS_TAG}..."

--- a/cmdline.h
+++ b/cmdline.h
@@ -52,6 +52,7 @@ struct gengetopt_args_info {
 	int encryptremproxy_flag;  /* Turn on local to remote proxy SSL encryption (def=off).*/
 	char *clientcert_arg;	/* client SSL certificate */
 	char *clientkey_arg;	/* client SSL key */
+	char *tpmkey_arg;	/* client TPM 2.0 SSL key */
 	int wa_bug_29744_flag;	/* Use SSL encryption only until CONNECT, if at all (def=off).*/
 	/* int no_ssl3_flag;		 Turn off SSLv3 (default=on) */
 	char *proctitle_arg;	/* Override process title (default=off). */
@@ -93,6 +94,7 @@ struct gengetopt_args_info {
 	/* int enforcetls1_given;    Wheter to enforce TLSv1 */
 	int host_given;         /* Wheter we override the Host Header */
 	int cacert_given;		/* Whether cacert was given */
+    int tpmkey_given;		/* Whether tpmkey was given */
 };
 
 int cmdline_parser( int argc, char * const *argv, struct gengetopt_args_info *args_info );

--- a/io.c
+++ b/io.c
@@ -1,4 +1,4 @@
-/* Proxytunnel - (C) 2001-2008 Jos Visser / Mark Janssen    */
+ /* Proxytunnel - (C) 2001-2008 Jos Visser / Mark Janssen    */
 /* Contact:                  josv@osp.nl / maniac@maniac.nl */
 
 /*
@@ -57,7 +57,7 @@ int readline(PTSTREAM *pts) {
 
 	if( args_info.verbose_flag ) {
 		/* Copy line of data into dstr without trailing newline */
-		char *dstr = calloc(1, strlen(buf) + 1);
+		char *dstr = malloc(strlen(buf) + 1);
 		strncpy( dstr, buf, strlen(buf));
 		if (strcmp(dstr, ""))
 			message( " <- %s\n", dstr );
@@ -89,10 +89,13 @@ void cpio(PTSTREAM *stream1, PTSTREAM *stream2) {
 	select_timeout.tv_sec = 30; /* should be fine */
 	select_timeout.tv_usec = 0;
 
-	if( args_info.verbose_flag )
+	if( args_info.verbose_flag ) {
 		message( "\nTunnel established.\n" );
-
-        int stream_status = ACTIVE;
+    }
+    if( args_info.proctitle_given ) {
+        message( "%s tunnel active\n", args_info.proctitle_arg );
+    }
+    int stream_status = ACTIVE;
 	while( stream_status == ACTIVE ) {
 		/* Clear the interesting socket sets */
 		FD_ZERO( &readfds );

--- a/proxytunnel.c
+++ b/proxytunnel.c
@@ -132,7 +132,7 @@ int tunnel_connect() {
 			message( "Connected to %s (local proxy)\n", args_info.proxy_arg );
 		}
 	}
-
+   
 	/* Return the socket */
 	return sd;
 }

--- a/ptstream.h
+++ b/ptstream.h
@@ -24,8 +24,11 @@
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 #include <openssl/pem.h>
+#include <openssl/provider.h>
 #include <openssl/ssl.h>
+#include <openssl/store.h>
 #endif
 
 typedef struct ptstream {


### PR DESCRIPTION
Hi there, I recently needed to extend proxytunnel to support TPM 2.0 generated SSL client keys, and this PR includes those code changes - you are welcome to it if you think it has utility. Adds support for TPM 2.0-backed private keys (TSS2 format) for SSL client certificate authentication via `tpm2-openssl`. Requires OpenSSL 3.x and the Provider for TPM2 integration (https://github.com/tpm2-software/tpm2-openssl):

`apt install tpm2-openssl tpm2-tools tpm2-abrmd libtss2-tcti-tabrmd0`

A functional TPM 2.0 device or software emulator must also be present  on the system.

This PR adds/re-animates cmdline option `-T` as `--tpmkey`, to provide a TSS2 formatted private key when using certificate authentication to the proxy.

To generate a CSR from the TPM, use:

`openssl req -new -newkey -provider tpm2 -provider default -propquery '?provider=tpm2' -sha256 -nodes -keyout sslclient.key -out sslclient.csr`

To use the TSS2 format private key for HTTPS proxy auth, use the `-T sslclient.key` argument in place of `-k`. Pass the PEM formatted certificate as normal. 

Also updated `buildwin.sh` to reflect OpenSSL 3.x via MSYS2 (msys-ssl-3.dll) though I doubt TPM functionality would actually work in Windows (only tested in Debian).

This was an interesting corner-case I had to solve but I'm not sure how much utility it will have for others. Feel free to reject this PR if this code adds too much complexity or let me know if there are stylistic or code changes you need.