### PR TITLE
Add link to setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ can enable SSL encryption (using -e), which will work around this
 problem, however, you need to setup stunnel4 on the other side, or
 connect to a process that understands SSL itself.
 
+A complete guide with illustrations for encrypted tunneling and
+server-side setup with Nginx, Apache or Caddy can be found in
+this article: [Tunneling corporate firewalls for developers](https://blog.frost.kiwi/tunneling-corporate-firewalls/)
+
 When all this is in place, execute an "ssh foobar" and you're in business!
 
 # Environment Variables


### PR DESCRIPTION
I'm a huge fan of this project. The setup ways are diverse and complicated, but as previously mentioned https://github.com/proxytunnel/proxytunnel/issues/62 I think there should be more documentation on how to do this server-side and what the underlying traffic is.

I created this complete guide: [Tunneling corporate firewalls for developers](https://blog.frost.kiwi/tunneling-corporate-firewalls/), when proxytunnel should be used, how nginx, apache or caddy have to be configured and illustrated all the possible configurations with svgs like this:
![tunneledHTTPS](https://github.com/user-attachments/assets/8c9158cc-e306-460d-a04f-f2fbf299fd32)

This PR links this guide in the Readme. The other way around, I'm also happy to include documentation in this project.
