### PR TITLE
Make `-ggdb` flag optional & non-default

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,46 @@ to build simply run `make` and optionally `make install`.
 If you manually want to install, copy proxytunnel to /usr/local/bin
 and optionally the manual-page from the debian-subdirectory to your manpath
 
+# Nix Flakes
+
+> NOTE: The Nix Flake installation currently only supports the default Makefile flags (i.e. GNU system assumed + SSL enabled).
+
+A simple Nix Flake is included to allow for use via flake inputs. To create a temporary Nix Shell with access to the `proxytunnel` binary, you can run the command:
+```console
+nix develop github:proxytunnel/proxytunnel
+```
+If you instead want to include it as a flake input, the following `flake.nix` shows how to do so:
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Add proxytunnel as an input
+    proxytunnel.url = "github:proxytunnel/proxytunnel";
+  };
+
+  outputs = {
+    nixpkgs,
+    proxytunnel,
+    ...
+  }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {system = "x86_64-linux";};
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      buildInputs = [ 
+        # Make the `proxytunnel` binary available in a Nix Shell
+        proxytunnel.packages.${system}.default
+
+        # And include any other packages as desired...
+        pkgs.gcc
+        pkgs.glibc.dev
+      ];
+    };
+  };
+}
+```
+
 # msys2
 
 To install msys2 with [chocolatey](https://chocolatey.org/install):

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ CC ?= cc
 CFLAGS ?= -Wall -O2 
 
 # Run `make DEBUG=1` or uncomment the next 2 lines to enable debug compile flags
-define (DEBUG)
-endef
+# define (DEBUG)
+# endef
 
 ifdef DEBUG
 	CFLAGS += -ggdb

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,15 @@ name = proxytunnel
 version = $(shell awk 'BEGIN { FS="\"" } /^\#define VERSION / { print $$2 }' config.h)
 
 CC ?= cc
-CFLAGS ?= -Wall -O2 -ggdb
+CFLAGS ?= -Wall -O2 
+
+# Run `make DEBUG=1` or uncomment the next 2 lines to enable debug compile flags
+define (DEBUG)
+endef
+
+ifdef DEBUG
+	CFLAGS += -ggdb
+endif
 
 # Comment on non-gnu systems
 OPTFLAGS += -DHAVE_GETOPT_LONG

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ CC ?= cc
 CFLAGS ?= -Wall -O2 
 
 # Run `make DEBUG=1` or uncomment the next 2 lines to enable debug compile flags
-# define (DEBUG)
+# define DEBUG 
+# 	1
 # endef
 
 ifdef DEBUG

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ version = $(shell awk 'BEGIN { FS="\"" } /^\#define VERSION / { print $$2 }' con
 CC ?= cc
 CFLAGS ?= -Wall -O2 
 
-# Run `make DEBUG=1` or uncomment the next 2 lines to enable debug compile flags
+# Run `make DEBUG=1` or uncomment the next 3 lines to enable debug compile flags
 # define DEBUG 
 # 	1
 # endef

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743448293,
-        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,57 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743448293,
+        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "A flake that provides the proxytunnel command";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    # TODO: Check functionality and add support for other architectures.
+    pkgs = nixpkgs.legacyPackages."x86_64-linux";
+  in {
+    packages.x86_64-linux.default = pkgs.stdenv.mkDerivation {
+      pname = "proxytunnel";
+
+      version = "1.0.0";
+
+      src = ./.;
+      nativeBuildInputs = [pkgs.gnumake];
+      buildInputs = [pkgs.openssl];
+
+      buildPhase = ''
+        make
+      '';
+
+      installPhase = ''
+        mkdir -p $out/bin
+        cp ./proxytunnel $out/bin
+      '';
+    };
+
+    devShells.x86_64-linux.default = pkgs.mkShell {
+      packages = [self.packages.x86_64-linux.default];
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,17 @@
       # TODO: Maybe add configuration options for toggling Makefile {C/LD/OPT}FLAGS
       systems = ["x86_64-linux"];
 
+      imports = [inputs.flake-parts.flakeModules.easyOverlay];
+
       perSystem = {
         config,
         pkgs,
         ...
       }: {
-        packages.default = config.packages.proxytunnel;
+        overlayAttrs = {
+          inherit (config.packages) proxytunnel;
+          enableSSL = true;
+        };
 
         packages.proxytunnel = pkgs.stdenv.mkDerivation {
           pname = "proxytunnel";
@@ -33,9 +38,15 @@
 
           installPhase = ''
             mkdir -p $out/bin
-            cp ./proxytunnel $out/bin
+            cp ./proxytunnel $out/bin/${
+              if config.overlayAttrs.enableSSL
+              then "proxytunnel-yes-ssl"
+              else "proxytunnel-no-ssl"
+            }
           '';
         };
+
+        packages.default = config.packages.proxytunnel;
 
         devShells.default = pkgs.mkShell {
           packages = [config.packages.default];

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         packages.proxytunnel = pkgs.stdenv.mkDerivation {
           pname = "proxytunnel";
-          version = "1.0.0";
+          version = "1.12.3";
           src = ./.;
 
           nativeBuildInputs = [pkgs.gnumake];

--- a/flake.nix
+++ b/flake.nix
@@ -9,41 +9,20 @@
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {
       # TODO: Add support for more systems once checked.
-      # TODO: Maybe add configuration options for toggling Makefile {C/LD/OPT}FLAGS
       systems = ["x86_64-linux"];
+
+      imports = [inputs.flake-parts.flakeModules.easyOverlay];
 
       perSystem = {
         config,
         pkgs,
         ...
       }: {
-        packages.proxytunnel = pkgs.callPackage (
-          {
-            enableSSL ? true,
-            stdenv,
-          }:
-            stdenv.mkDerivation {
-              pname = "proxytunnel";
-              version = "1.12.3";
-              src = ./.;
+        overlayAttrs = {
+          inherit (config.packages) proxytunnel;
+        };
 
-              nativeBuildInputs = [pkgs.gnumake];
-              buildInputs = [pkgs.openssl];
-
-              buildPhase = ''
-                make
-              '';
-
-              installPhase = ''
-                mkdir -p $out/bin
-                cp ./proxytunnel $out/bin/${
-                  if enableSSL
-                  then "proxytunnel-yes-ssl"
-                  else "proxytunnel-no-ssl"
-                }
-              '';
-            }
-        ) {};
+        packages.proxytunnel = pkgs.callPackage ./nix/proxytunnel.nix {};
         packages.default = config.packages.proxytunnel;
 
         devShells.default = pkgs.mkShell {

--- a/nix/proxytunnel.nix
+++ b/nix/proxytunnel.nix
@@ -8,8 +8,7 @@
     if use-ssl
     then "-DUSE_SSL"
     else ""
-  }
-    ${
+  } ${
     if gnu-system
     then "-DHAVE_GETOPT_LONG"
     else ""

--- a/nix/proxytunnel.nix
+++ b/nix/proxytunnel.nix
@@ -1,0 +1,31 @@
+{
+  enableSSL ? true,
+  set-proc-title ? true,
+  pkgs,
+}: let
+  optflags = "${
+    if enableSSL
+    then "-DUSE_SSL"
+    else ""
+  } ${
+    if set-proc-title
+    then "-DSETPROCTITLE -DSPT_TYPE=2"
+    else ""
+  }";
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "proxytunnel";
+    version = "1.12.3";
+    src = ./..;
+
+    buildInputs = [pkgs.openssl];
+
+    buildPhase = ''
+      make OPTFLAGS="${optflags}"
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ./proxytunnel $out/bin
+    '';
+  }

--- a/nix/proxytunnel.nix
+++ b/nix/proxytunnel.nix
@@ -1,11 +1,12 @@
 {
-  enableSSL ? true,
+  gnu-system ? true,
   set-proc-title ? true,
   pkgs,
 }: let
-  optflags = "${
-    if enableSSL
-    then "-DUSE_SSL"
+  # TODO: Due to the way the OPENSSL_VERSION_NUMBER macro is checked, the -DUSE_SSL flag is NECESSARY
+  optflags = "-DUSE_SSL ${
+    if gnu-system
+    then "-DHAVE_GETOPT_LONG"
     else ""
   } ${
     if set-proc-title

--- a/nix/proxytunnel.nix
+++ b/nix/proxytunnel.nix
@@ -1,10 +1,15 @@
 {
+  use-ssl ? true,
   gnu-system ? true,
   set-proc-title ? true,
   pkgs,
 }: let
-  # TODO: Due to the way the OPENSSL_VERSION_NUMBER macro is checked, the -DUSE_SSL flag is NECESSARY
-  optflags = "-DUSE_SSL ${
+  optflags = "${
+    if use-ssl
+    then "-DUSE_SSL"
+    else ""
+  }
+    ${
     if gnu-system
     then "-DHAVE_GETOPT_LONG"
     else ""

--- a/ntlm.c
+++ b/ntlm.c
@@ -46,11 +46,13 @@
 #define DOMAIN_BUFLEN 256
 #define LM2_DIGEST_LEN 24
 
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 const EVP_MD *md4alg;
 const EVP_MD *md5alg;
 EVP_MD_CTX *mdctx;
 #endif
+#endif /* ifdef USE_SSL */
 
 int ntlm_challenge = 0;
 void message( char *s, ... );

--- a/ntlm.c
+++ b/ntlm.c
@@ -28,6 +28,7 @@
 #include "proxytunnel.h"
 #include <ctype.h>
 #include <sys/time.h>
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	#ifdef CYGWIN
 		#include <unistd.h>
@@ -38,6 +39,7 @@
 	#include <openssl/md4.h>
 	#include <openssl/md5.h>
 #endif
+#endif /* USE_SSL */
 
 #define TYPE1_DATA_SEG 8
 #define TYPE2_BUF_SIZE 2048
@@ -73,6 +75,7 @@ uint32_t flags;
 unsigned char lm2digest[LM2_DIGEST_LEN];
 
 void init_ntlm() {
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	OSSL_PROVIDER *provider;
 	provider = OSSL_PROVIDER_load(NULL, "default");
@@ -127,6 +130,7 @@ void init_ntlm() {
 	md5alg = EVP_md5();
 	mdctx = EVP_MD_CTX_new();
 #endif
+#endif /* ifdef USE_SSL */
 }
 
 void build_type1() {
@@ -308,10 +312,12 @@ unsigned char* key; /* pointer to authentication key */
 int key_len; /* length of authentication key */
 unsigned char digest[16]; /* caller digest to be filled in */
 {
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #else
 	MD5_CTX context;
 #endif
+#endif /* ifdef USE_SSL */
 	unsigned char k_ipad[65];    /* inner padding - key XORd with ipad */
 	unsigned char k_opad[65];    /* outer padding - key XORd with opad */
 	unsigned char tk[16];
@@ -319,6 +325,7 @@ unsigned char digest[16]; /* caller digest to be filled in */
 
 	/* if key is longer than 64 bytes reset it to key=MD5(key) */
 	if (key_len > 64) {
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 		EVP_DigestInit_ex(mdctx, md5alg, NULL);
 		EVP_DigestUpdate(mdctx, key, key_len);
@@ -328,6 +335,7 @@ unsigned char digest[16]; /* caller digest to be filled in */
 		MD5_Update(&context, key, key_len);
 		MD5_Final(tk, &context);
 #endif
+#endif /* ifdef USE_SSL */
 		key = tk;
 		key_len = 16;
 	}
@@ -356,6 +364,7 @@ unsigned char digest[16]; /* caller digest to be filled in */
 	}
 
 	/* perform inner MD5 */
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	EVP_DigestInit_ex(mdctx, md5alg, NULL);  /* init context for 1st pass */
 	EVP_DigestUpdate(mdctx, k_ipad, 64);     /* start with inner pad */
@@ -380,15 +389,18 @@ unsigned char digest[16]; /* caller digest to be filled in */
 	MD5_Update(&context, digest, 16);     /* then results of 1st hash */
 	MD5_Final(digest, &context);          /* finish up 2nd pass */
 #endif
+#endif /* ifdef USE_SSL */
 }
 
 void build_ntlm2_response() {
 	int i, j;
 	int passlen = 0;
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #else
 	MD4_CTX passcontext;
 #endif
+#endif /* ifdef USE_SSL */
 	unsigned char passdigest[16];
 	unsigned char *userdom;
 	int userdomlen;
@@ -413,6 +425,7 @@ void build_ntlm2_response() {
 		}
 	}
 
+#ifdef USE_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	EVP_DigestInit_ex(mdctx, md4alg, NULL);
 	EVP_DigestUpdate(mdctx, unipasswd, passlen);
@@ -422,6 +435,7 @@ void build_ntlm2_response() {
 	MD4_Update (&passcontext, unipasswd, passlen);
 	MD4_Final (passdigest, &passcontext);
 #endif
+#endif /* ifdef USE_SSL */
 
 	if( args_info.verbose_flag ) {
 		message("NTLM: MD4 of password is: ");


### PR DESCRIPTION
The `-ggdb` debug flag is included by default, which is not good practice.

To fix, I added a small macro to `Makefile` which conditionally adds `-ggdb` to `CFLAGS`. This can be invoked by running:
```console
$ make DEBUG=1
```
Additionally, to keep in spirit with the current Makefile structure, the define macro can also be uncommented as follows:
```make
# Makefile

# ...

# Run `make DEBUG=1` or uncomment the next 3 lines to enable debug compile flags
# define DEBUG 
# 	1
# endef

ifdef DEBUG
	CFLAGS += -ggdb
endif
```
